### PR TITLE
Update of given example scripts.

### DIFF
--- a/examples/publish_with_jwt_and_seed.go
+++ b/examples/publish_with_jwt_and_seed.go
@@ -6,23 +6,23 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"fmt"
+	"time"
 
 	"github.com/Synternet/pubsub-go/pubsub"
 	"github.com/nats-io/nats.go"
 )
 
 const (
-	natsUrl                 = "nats://127.0.0.1:4222"
+	natsUrl                 = "nats://127.0.0.1"
 	userCredsJWT            = "USER_JWT"
 	accessToken             = "EXAMPLE_ACCESS_TOKEN"
-	exampleSubscribeSubject = "example.sub.subject"
-	examplePublishSubject   = "example.pub.subject"
+	examplePublishSubject   = "publisher.example.subject"
 )
 
 // RepublishData receives a message on a given subject and republishes it to another subject.
 // It takes a context, the service instance, and the data (message) as input arguments.
-func RepublishData(ctx context.Context, service *pubsub.NatsService, data []byte) error {
-	log.Println("Received message on", exampleSubscribeSubject, "subject")
+func PublishData(ctx context.Context, service *pubsub.NatsService, data []byte) error {
 	err := service.Publish(ctx, examplePublishSubject, data)
 	if err != nil {
 		return err
@@ -32,6 +32,7 @@ func RepublishData(ctx context.Context, service *pubsub.NatsService, data []byte
 }
 
 func main() {
+
 	// Set user credentials and options for NATS connection.
 	opts := []nats.Option{}
 	opts = append(opts, nats.UserJWTAndSeed(userCredsJWT, accessToken))
@@ -48,10 +49,18 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Add a handler function to process messages received on the exampleSubscribeSubject.
-	service.AddHandler(exampleSubscribeSubject, func(data []byte) error {
-		return RepublishData(ctx, service, data)
-	})
+	// Publish messages in a continuous loop
+	value := 0
+	for {
+		msg := fmt.Sprintf("Value: %d", value)
+		if err := service.Publish(ctx, examplePublishSubject, []byte(msg)); err != nil {
+			log.Printf("Failed to publish message: %v", err)
+		} else {
+			fmt.Printf("Published message: %s\n", msg)
+		}
+		value++
+		time.Sleep(1 * time.Second)
+	}
 
 	// Set up signal handling to gracefully shut down when receiving SIGINT or SIGTERM signals.
 	signalChan := make(chan os.Signal, 1)

--- a/examples/subscribe_with_seed.go
+++ b/examples/subscribe_with_seed.go
@@ -14,13 +14,13 @@ import (
 const (
 	natsUrl                 = "nats://127.0.0.1"
 	accessToken             = "EXAMPLE_ACCESS_TOKEN"
-	exampleSubscribeSubject = "example.sub.subject"
+	exampleSubscribeSubject = "synternet.example.subject"
 )
 
 // RepublishData receives a message on a given subject and republishes it to another subject.
 // It takes a context, the service instance, and the data (message) as input arguments.
 func PrintData(ctx context.Context, service *pubsub.NatsService, data []byte) error {
-	log.Println("Received message on", exampleSubscribeSubject, "subject")
+	log.Printf("Received message on subject %s: %s\n", exampleSubscribeSubject, string(data))
 	return nil
 }
 


### PR DESCRIPTION
## Description
Updating outdated example scripts. Subscribe example - minor changes but pubsub.go and pubsub_with_creds_file.go required a rework due to deprecated scenarios comparing to Synternet Portal.

## Proposed Changes
List the specific changes or additions made in this PR.

- subscribe_with_seed.go - changing PrintData() function to actual print incoming subject messages instead of just generic print
- pubsub.go -> publish_with_jwt_and_seed.go: complete rework by converting script to only publishing scenario and adding a loop for sending simple messages.
- pubusb_with_creds_file.go -> republish_using_creds_files.go: compete rework of republishing scenario due to deprecated actions. Previously script used single creds file to subscribe and publish but because Synternet requires separate profiles for that - I split these action into two separate cred/key pairs.

## Checklist
- [X] I have tested these changes locally
- [X] I have reviewed the code for any potential issues
- [X] I have documented any necessary changes

